### PR TITLE
Added support for injection interceptors

### DIFF
--- a/docs/maturity-levels.md
+++ b/docs/maturity-levels.md
@@ -1,6 +1,6 @@
 # Maturity Levels
 
-The quality of different OpenTracing instrumentation libraries that exist out there in the wild varies greatly. The following maturity levels can be used to classify different libraries and highlight there capabilities or shortcomings.
+The quality of different OpenTracing instrumentation libraries that exist out there in the wild varies greatly. The following maturity levels can be used to classify different libraries and highlight their capabilities or shortcomings.
 
 ## 🌧️ Level 1: Take it or leave it
 

--- a/opentracing-jdbc/opentracing-jdbc/src/main/java/org/zalando/opentracing/jdbc/operation/OperationName.java
+++ b/opentracing-jdbc/opentracing-jdbc/src/main/java/org/zalando/opentracing/jdbc/operation/OperationName.java
@@ -8,7 +8,6 @@ import java.util.List;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 @API(status = EXPERIMENTAL)
-@FunctionalInterface
 public interface OperationName {
 
     String generate(Method method, List<String> queries);

--- a/opentracing-proxy/opentracing-proxy/pom.xml
+++ b/opentracing-proxy/opentracing-proxy/pom.xml
@@ -20,6 +20,7 @@
             <artifactId>guava</artifactId>
             <version>28.1-jre</version>
         </dependency>
+        <!-- TODO only used in one place right now... -->
         <dependency>
             <groupId>org.organicdesign</groupId>
             <artifactId>Paguro</artifactId>

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/BaggageListener.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/BaggageListener.java
@@ -8,8 +8,11 @@ import java.util.Arrays;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 @API(status = MAINTAINED)
-@FunctionalInterface
 public interface BaggageListener extends Plugin {
+
+    BaggageListener DEFAULT = (span, key, value) -> {
+        // nothing to implement
+    };
 
     void onBaggage(Span span, String key, String value);
 

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/CompositeInjection.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/CompositeInjection.java
@@ -1,0 +1,27 @@
+package org.zalando.opentracing.proxy;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+final class CompositeInjection implements Injection {
+
+    private final Iterable<Injection> interceptors;
+
+    @Override
+    public Injector intercept(
+            final Injector injector,
+            final SpanContext context,
+            final Format<?> format) {
+
+        Injector result = injector;
+
+        for (final Injection interceptor : interceptors) {
+            result = interceptor.intercept(result, context, format);
+        }
+
+        return result;
+    }
+
+}

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Injection.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Injection.java
@@ -1,0 +1,42 @@
+package org.zalando.opentracing.proxy;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import org.apiguardian.api.API;
+
+import java.util.Arrays;
+
+import static org.zalando.opentracing.proxy.Injection.Injector.NOOP;
+
+@API(status = API.Status.EXPERIMENTAL)
+public interface Injection extends Plugin {
+
+    Injection DEFAULT = (injector, context, format) -> injector;
+    Injection DISABLE = (injector, context, format) -> NOOP;
+
+    interface Injector {
+        Injector NOOP = NoopInjector.NOOP;
+        <C> void inject(SpanContext context, Format<C> format, C carrier);
+    }
+
+    Injector intercept(
+            Injector injector,
+            SpanContext context,
+            Format<?> format);
+
+    @Override
+    default <R extends Registry<R>> R registerTo(final R registry) {
+        return registry.withInjection(this);
+    }
+
+    static Injection composite(
+            final Injection... interceptors) {
+        return composite(Arrays.asList(interceptors));
+    }
+
+    static Injection composite(
+            final Iterable<Injection> interceptors) {
+        return new CompositeInjection(interceptors);
+    }
+
+}

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/LogListener.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/LogListener.java
@@ -10,8 +10,11 @@ import static java.util.Collections.singletonMap;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 @API(status = MAINTAINED)
-@FunctionalInterface
 public interface LogListener extends Plugin {
+
+    LogListener DEFAULT = (span, fields) -> {
+        // nothing to implement
+    };
 
     default void onLog(
             final Span span,

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Naming.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Naming.java
@@ -7,8 +7,9 @@ import java.util.function.UnaryOperator;
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 @API(status = MAINTAINED)
-@FunctionalInterface
 public interface Naming extends Plugin {
+
+    Naming DEFAULT = name -> name;
 
     String rename(String operationName);
 

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/NoopInjector.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/NoopInjector.java
@@ -1,0 +1,19 @@
+package org.zalando.opentracing.proxy;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import org.zalando.opentracing.proxy.Injection.Injector;
+
+enum NoopInjector implements Injector {
+
+    NOOP;
+
+    @Override
+    public <C> void inject(
+            final SpanContext context,
+            final Format<C> format,
+            final C carrier) {
+        // do nothing
+    }
+
+}

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Options.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Options.java
@@ -1,59 +1,9 @@
 package org.zalando.opentracing.proxy;
 
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import io.opentracing.Tracer.SpanBuilder;
 import lombok.AllArgsConstructor;
-
-import java.util.Map;
 
 @AllArgsConstructor
 final class Options implements Registry<Options> {
-
-    private static final class Defaults {
-
-        static final Naming ORIGINAL = name -> name;
-
-        enum SpanBuilderInterceptors implements SpanBuilderInterceptor {
-            NONE;
-
-            @Override
-            public SpanBuilder intercept(final Tracer tracer, final SpanBuilder builder) {
-                return builder;
-            }
-        }
-
-        enum TagListeners implements TagListener {
-            NONE
-        }
-
-        enum LogListeners implements LogListener {
-            NONE;
-
-            @Override
-            public void onLog(final Span span, final Map<String, ?> fields) {
-                // nothing to do
-            }
-        }
-
-        enum BaggageListeners implements BaggageListener {
-            NONE;
-
-            @Override
-            public void onBaggage(final Span span, final String key, final String value) {
-                // nothing to do
-            }
-        }
-
-        enum SpanListeners implements SpanListener {
-            NONE
-        }
-
-        enum ScopeListeners implements ScopeListener {
-            NONE
-        }
-
-    }
 
     private final Naming naming;
     private final SpanBuilderInterceptor spanBuilderInterceptor;
@@ -62,16 +12,18 @@ final class Options implements Registry<Options> {
     private final BaggageListener baggageListener;
     private final SpanListener spanListener;
     private final ScopeListener scopeListener;
+    private final Injection injection;
 
     Options() {
         this(
-                Defaults.ORIGINAL,
-                Defaults.SpanBuilderInterceptors.NONE,
-                Defaults.TagListeners.NONE,
-                Defaults.LogListeners.NONE,
-                Defaults.BaggageListeners.NONE,
-                Defaults.SpanListeners.NONE,
-                Defaults.ScopeListeners.NONE);
+                Naming.DEFAULT,
+                SpanBuilderInterceptor.DEFAULT,
+                TagListener.DEFAULT,
+                LogListener.DEFAULT,
+                BaggageListener.DEFAULT,
+                SpanListener.DEFAULT,
+                ScopeListener.DEFAULT,
+                Injection.DEFAULT);
     }
 
     @Override
@@ -83,7 +35,8 @@ final class Options implements Registry<Options> {
                 logListener,
                 baggageListener,
                 spanListener,
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -100,7 +53,8 @@ final class Options implements Registry<Options> {
                 logListener,
                 baggageListener,
                 spanListener,
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -114,7 +68,8 @@ final class Options implements Registry<Options> {
                 logListener,
                 baggageListener,
                 spanListener,
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -128,7 +83,8 @@ final class Options implements Registry<Options> {
                         additionalLogListener),
                 baggageListener,
                 spanListener,
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -144,7 +100,8 @@ final class Options implements Registry<Options> {
                         baggageListener,
                         additionalBaggageListener),
                 spanListener,
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -160,7 +117,8 @@ final class Options implements Registry<Options> {
                 SpanListener.composite(
                         spanListener,
                         additionalSpanListener),
-                scopeListener);
+                scopeListener,
+                injection);
     }
 
     @Override
@@ -176,7 +134,25 @@ final class Options implements Registry<Options> {
                 spanListener,
                 ScopeListener.composite(
                         scopeListener,
-                        additionalScopeListener));
+                        additionalScopeListener),
+                injection);
+    }
+
+    public Options withInjection(
+            final Injection additionalInjection) {
+
+        return new Options(
+                naming,
+                spanBuilderInterceptor,
+                tagListener,
+                logListener,
+                baggageListener,
+                spanListener,
+                scopeListener,
+                Injection.composite(
+                        injection,
+                        additionalInjection
+                ));
     }
 
     Naming naming() {
@@ -205,6 +181,10 @@ final class Options implements Registry<Options> {
 
     ScopeListener scopes() {
         return scopeListener;
+    }
+
+    Injection injections() {
+        return injection;
     }
 
 }

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/ProxyTracer.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/ProxyTracer.java
@@ -3,7 +3,9 @@ package org.zalando.opentracing.proxy;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
 import lombok.AllArgsConstructor;
 import org.apiguardian.api.API;
 
@@ -28,6 +30,17 @@ public final class ProxyTracer extends ForwardingTracer {
     @Override
     protected Tracer delegate() {
         return delegate;
+    }
+
+    @Override
+    public <C> void inject(
+            final SpanContext context,
+            final Format<C> format,
+            final C carrier) {
+
+        options.injections()
+                .intercept(super::inject, context, format)
+                .inject(context, format, carrier);
     }
 
     public ProxyTracer with(final Plugin plugin) {

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Registry.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/Registry.java
@@ -14,5 +14,6 @@ public interface Registry<R extends Registry<R>> {
     R withBaggageListener(BaggageListener baggageListener);
     R withSpanListener(SpanListener spanListener);
     R withScopeListener(ScopeListener scopeListener);
+    R withInjection(Injection interceptor);
 
 }

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/ScopeListener.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/ScopeListener.java
@@ -11,6 +11,10 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 @API(status = MAINTAINED)
 public interface ScopeListener extends Plugin {
 
+    ScopeListener DEFAULT = new ScopeListener() {
+        // nothing to implement
+    };
+
     default void onActivated(final Scope scope, final Span span) {
         // nothing to do
     }

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/SpanBuilderInterceptor.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/SpanBuilderInterceptor.java
@@ -12,6 +12,8 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 @API(status = EXPERIMENTAL)
 public interface SpanBuilderInterceptor extends Plugin {
 
+    SpanBuilderInterceptor DEFAULT = (tracer, builder) -> builder;
+
     SpanBuilder intercept(Tracer tracer, SpanBuilder builder);
 
     @Override

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/SpanListener.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/SpanListener.java
@@ -10,6 +10,10 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 @API(status = MAINTAINED)
 public interface SpanListener extends Plugin {
 
+    SpanListener DEFAULT = new SpanListener() {
+        // nothing to implement
+    };
+
     default void onStarted(final Span span) {
         // nothing to do
     }

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/TagListener.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/TagListener.java
@@ -12,6 +12,10 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 @API(status = MAINTAINED)
 public interface TagListener extends Plugin {
 
+    TagListener DEFAULT = new TagListener() {
+        // nothing to implement
+    };
+
     default <T> void onTag(
             final SpanBuilder builder,
             final Tag<T> tag,

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/TagPropagation.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/TagPropagation.java
@@ -33,7 +33,8 @@ public final class TagPropagation implements SpanBuilderInterceptor {
     }
 
     @Override
-    public SpanBuilder intercept(final Tracer tracer, final SpanBuilder builder) {
+    public SpanBuilder intercept(
+            final Tracer tracer, final SpanBuilder builder) {
         return new PropagatingSpanBuilder(tracer, builder);
     }
 

--- a/opentracing-proxy/opentracing-proxy/src/test/java/org/zalando/opentracing/proxy/InjectionTest.java
+++ b/opentracing-proxy/opentracing-proxy/src/test/java/org/zalando/opentracing/proxy/InjectionTest.java
@@ -1,0 +1,72 @@
+package org.zalando.opentracing.proxy;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapAdapter;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.opentracing.propagation.Format.Builtin.BINARY_INJECT;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP;
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+class InjectionTest {
+
+    @AllArgsConstructor
+    static class DisableFormat implements Injection {
+
+        private final Format<?> disabled;
+
+        @Override
+        public Injector intercept(
+                final Injector injector,
+                final SpanContext context,
+                final Format<?> format) {
+
+            if (format.equals(disabled)) {
+                return Injector.NOOP;
+            }
+
+            return injector;
+        }
+
+    }
+
+    @Test
+    void injects() {
+        final Tracer unit = disable(BINARY_INJECT);
+        assertThat(injectTextMap(unit), is(not(emptyMap())));
+    }
+
+    @Test
+    void doesntInject() {
+        final Tracer unit = disable(TEXT_MAP);
+        assertThat(injectTextMap(unit), is(emptyMap()));
+    }
+
+    private <C> Tracer disable(final Format<C> format) {
+        return new ProxyTracer(new MockTracer())
+                .with(new DisableFormat(format));
+    }
+
+    private Span newSpan(final Tracer tracer) {
+        return tracer.buildSpan("test").start();
+    }
+
+    private Map<String, String> injectTextMap(final Tracer unit) {
+        final SpanContext context = newSpan(unit).context();
+        final Map<String, String> map = new HashMap<>();
+        unit.inject(context, TEXT_MAP, new TextMapAdapter(map));
+        return map;
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the ability to intercept span context injection.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is needed to conditionally skip span context injection, e.g. when spans are effectively temporarily disabled by using `NoopSpan` (see #338) which would cause `ClassCastException`s otherwise.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
