### PR TITLE
Use handler method name as operation name

### DIFF
--- a/opentracing-spring-extension/opentracing-spring-web-extension/src/main/java/org/zalando/opentracing/spring/web/extension/StandardSpanDecorator.java
+++ b/opentracing-spring-extension/opentracing-spring-web-extension/src/main/java/org/zalando/opentracing/spring/web/extension/StandardSpanDecorator.java
@@ -14,6 +14,7 @@ public final class StandardSpanDecorator extends ForwardingSpanDecorator {
                 new ErrorSpanDecorator(),
                 new ErrorStackSpanDecorator(),
                 new HttpPathSpanDecorator(),
+                HANDLER_METHOD_OPERATION_NAME,
                 new ServiceLoaderSpanDecorator()
         ));
     }

--- a/opentracing-spring-extension/opentracing-spring-web-extension/src/test/java/org/zalando/opentracing/spring/web/extension/StandardSpanDecoratorTest.java
+++ b/opentracing-spring-extension/opentracing-spring-web-extension/src/test/java/org/zalando/opentracing/spring/web/extension/StandardSpanDecoratorTest.java
@@ -120,6 +120,14 @@ class StandardSpanDecoratorTest {
     }
 
     @Test
+    void shouldNameOperation() {
+        client.getForEntity("http://localhost:8080/names/123", String.class);
+        waitFor(Duration.ofSeconds(1));
+
+        assertThat(span().operationName(), is("getName"));
+    }
+
+    @Test
     void shouldTagRegularPath() {
         final ResponseEntity<String> response = client
                 .getForEntity("http://localhost:8080/greet?name=Alice", String.class);


### PR DESCRIPTION
## Description

Use handler method name as operation name instead of HTTP method name.

## Motivation and Context

* default operation names are boring ("`GET`")
* `io.opentracing.contrib.spring.web` uses handler method name without toolbox
* I am not adding `HandlerInterceptorSpanDecorator.STANDARD_LOGS` (which `io.opentracing.contrib.spring.web` registers by default without the toolbox) because I don't like it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
