### PR TITLE
Ensure correlation via baggage on forwarded spans

### DIFF
--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/plugin/LogCorrelation.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/plugin/LogCorrelation.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
@@ -86,9 +87,13 @@ public final class LogCorrelation implements ScopeListener, BaggageListener {
             final String baggageKey,
             final String value) {
 
-        @Nullable final Span activeSpan = tracer.activeSpan();
+        final Function<Span, String> toSpanId = s -> s.context().toSpanId();
 
-        if (span.equals(activeSpan)) {
+        @Nullable final String activeSpanId = Optional.ofNullable(tracer.activeSpan())
+                .map(toSpanId)
+                .orElse(null);
+
+        if (toSpanId.apply(span).equals(activeSpanId)) {
             Optional.ofNullable(baggage.get(baggageKey))
                     .ifPresent(contextKey -> MDC.put(contextKey, value));
         }

--- a/opentracing-proxy/opentracing-proxy/src/test/java/org/zalando/opentracing/proxy/plugin/LogCorrelationTest.java
+++ b/opentracing-proxy/opentracing-proxy/src/test/java/org/zalando/opentracing/proxy/plugin/LogCorrelationTest.java
@@ -10,8 +10,8 @@ import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.propagation.TextMapExtractAdapter;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
+import org.zalando.opentracing.proxy.base.ForwardingSpan;
 import org.zalando.opentracing.proxy.core.ProxyTracer;
-import org.zalando.opentracing.proxy.plugin.LogCorrelation;
 
 import java.util.HashMap;
 
@@ -109,6 +109,17 @@ class LogCorrelationTest {
             final Span child = unit.buildSpan("child").start();
             child.setBaggageItem("request-id", "P6QQkzZHfza9GO");
             assertNull(MDC.get("request_id"));
+        }
+    }
+
+    @Test
+    void correlatesBaggageWhenSpanIsForwarding() {
+        final Span span = unit.buildSpan("test").start();
+        final ForwardingSpan wrapped = () -> span;
+
+        try (final Scope ignored = unit.activateSpan(wrapped)) {
+            span.setBaggageItem("request-id", "P6QQkzZHfza9GO");
+            assertEquals("P6QQkzZHfza9GO", MDC.get("request_id"));
         }
     }
 


### PR DESCRIPTION
## Description

* change active-span-check to assert on span-id only to not fail if spans are wrapped (forwarded) e.g. due to auto-tagging.

## Motivation and Context

* ensures baggage items are put into `MDC` as configured for log correlation.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have added tests to cover my changes.
