### PR TITLE
Unifies SECURITY.md to point to the Zalando security form

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,5 +4,4 @@ We are trying to deal with it responsibly and provide patches as quickly as  pos
 us please use any of the following channels:
 
 - open an [issue](../../issues)
-- send an [email](mailto:tech-security@zalando.de)
-- report through our [bug bounty program](https://hackerone.com/zalando)
+- use our [security form](https://corporate.zalando.com/en/services-and-contact#security-form)


### PR DESCRIPTION
Unifies SECURITY.md to point to the Zalando security form.

## Description

## Motivation and Context
The majority of projects links to the security form. We still have some repositories that point to e-mail boxes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
