### PR TITLE
DefaultTracer#writeTo now tolerates NoopTracer

### DIFF
--- a/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/DefaultFlow.java
+++ b/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/DefaultFlow.java
@@ -59,7 +59,10 @@ final class DefaultFlow implements Flow {
 
     @Override
     public void writeTo(final BiConsumer<String, String> writer) {
-        writer.accept(Header.FLOW_ID, currentId());
+        extractor.extract(activeSpan())
+                .map(FlowId::getValue)
+                .ifPresent(value ->
+                        writer.accept(Header.FLOW_ID, value));
     }
 
     @Override

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
@@ -1,15 +1,39 @@
 package org.zalando.opentracing.flowid;
 
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultFlowNoopTracerTest {
-    private final Flow unit = Flow.create(NoopTracerFactory.create());
+    NoopTracer tracer = NoopTracerFactory.create();
+    private final Flow unit = Flow.create(tracer);
 
     @Test
     void shouldThrowNoActiveSpanFoundException() {
         assertThrows(IllegalStateException.class, unit::currentId);
+    }
+
+    @Test
+    void writeToShouldNotThrow() {
+        final Span span = tracer.buildSpan("test").start();
+
+        try (final Scope ignored = tracer.activateSpan(span)) {
+            final Map<String, String> target = new HashMap<>();
+
+            unit.writeTo(target::put);
+
+            assertEquals(emptyMap(), target);
+        }
     }
 }

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
@@ -1,13 +1,8 @@
 package org.zalando.opentracing.flowid;
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.mock.MockSpan;
-import io.opentracing.noop.NoopTracer;
 import io.opentracing.noop.NoopTracerFactory;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,8 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DefaultFlowNoopTracerTest {
-    NoopTracer tracer = NoopTracerFactory.create();
-    private final Flow unit = Flow.create(tracer);
+    private final Flow unit = Flow.create(NoopTracerFactory.create());
 
     @Test
     void shouldThrowNoActiveSpanFoundException() {
@@ -26,14 +20,8 @@ class DefaultFlowNoopTracerTest {
 
     @Test
     void writeToShouldNotThrow() {
-        final Span span = tracer.buildSpan("test").start();
-
-        try (final Scope ignored = tracer.activateSpan(span)) {
-            final Map<String, String> target = new HashMap<>();
-
-            unit.writeTo(target::put);
-
-            assertEquals(emptyMap(), target);
-        }
+        final Map<String, String> target = new HashMap<>();
+        unit.writeTo(target::put);
+        assertEquals(emptyMap(), target);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When used with a NoopTracer (or generally any Span which doesn't allow extracting any useful identifier), DefaultFlow.writeTo now will just not do anything, instead of throwing an IllegalStateException.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It allows running an application when no proper tracing implementation is available, e.g. when running it locally.
This should fix #522.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

If any user depended on an exception being thrown by `Flow.writeTo(...)` in this case, this would break.
But as there is no documentation for writeTo, it's unclear whether this is part of the contract or not.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

I didn't find any documentation of `writeTo`, so I don't think there is any which needs to be updated.