### PR TITLE
don't use native-mt

### DIFF
--- a/opentracing-kotlin/pom.xml
+++ b/opentracing-kotlin/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.jetbrains.kotlinx</groupId>
       <artifactId>kotlinx-coroutines-core</artifactId>
-      <version>1.4.3-native-mt</version>
+      <version>1.4.3</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/opentracing-kotlin/src/test/kotlin/org/zalando/opentracing/kotlin/TracerExtensionsTest.kt
+++ b/opentracing-kotlin/src/test/kotlin/org/zalando/opentracing/kotlin/TracerExtensionsTest.kt
@@ -32,12 +32,14 @@ class TracerExtensionsTest : FunSpec({
             Tags.COMPONENT.key to "test"
         )
 
-        tracer.injectToMap(span)?.shouldContainExactly(
-            mapOf(
-                "spanid" to "6",
-                "traceid" to "5"
+        (span as MockSpan).let {
+            tracer.injectToMap(it)?.shouldContainExactly(
+                mapOf(
+                    "spanid" to it.context().spanId().toString(),
+                    "traceid" to it.context().traceId().toString()
+                )
             )
-        )
+        }
     }
 
     test("get context from map") {


### PR DESCRIPTION
native-mt is a different flavour of coroutines implementation meant for Kotlin native. this is not the dependency we want to use.
