### PR TITLE
remove support for Spring 4 and Spring Boot 1.5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        profile: ['', 'spring4']
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java adoptopenjdk-8.0.322+6

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,3 @@
-Willi Schönborn <w.schoenborn@gmail.com>
+Gregor Zeitlinger <gregor.zeitlinger@zalando.de>
 Lukas Niemeier <lukas.niemeier@zalando.de>
 Bartosz Ocytko <bocytko@gmail.com>

--- a/opentracing-flowid/opentracing-flowid-autoconfigure/pom.xml
+++ b/opentracing-flowid/opentracing-flowid-autoconfigure/pom.xml
@@ -121,21 +121,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-jdbc/opentracing-jdbc-autoconfigure/pom.xml
+++ b/opentracing-jdbc/opentracing-jdbc-autoconfigure/pom.xml
@@ -58,21 +58,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-proxy/opentracing-proxy-autoconfigure/pom.xml
+++ b/opentracing-proxy/opentracing-proxy-autoconfigure/pom.xml
@@ -89,21 +89,4 @@
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-servlet-extension/opentracing-servlet-extension-autoconfigure/pom.xml
+++ b/opentracing-servlet-extension/opentracing-servlet-extension-autoconfigure/pom.xml
@@ -65,21 +65,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-servlet-extension/opentracing-servlet-extension/pom.xml
+++ b/opentracing-servlet-extension/opentracing-servlet-extension/pom.xml
@@ -87,21 +87,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-spring-extension/opentracing-spring-web-extension-autoconfigure/pom.xml
+++ b/opentracing-spring-extension/opentracing-spring-web-extension-autoconfigure/pom.xml
@@ -65,21 +65,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-spring-extension/opentracing-spring-web-extension/pom.xml
+++ b/opentracing-spring-extension/opentracing-spring-web-extension/pom.xml
@@ -101,21 +101,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>spring4</id>
-            <dependencies>
-                <dependency>
-                    <groupId>com.github.sbrannen</groupId>
-                    <artifactId>spring-test-junit5</artifactId>
-                </dependency>
-            </dependencies>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>

--- a/opentracing-spring-extension/pom.xml
+++ b/opentracing-spring-extension/pom.xml
@@ -14,22 +14,8 @@
         <module>opentracing-spring-web-extension</module>
         <module>opentracing-spring-web-extension-autoconfigure</module>
         <module>opentracing-spring-web-extension-starter</module>
+        <module>opentracing-spring-webflux-extension</module>
+        <module>opentracing-spring-webflux-extension-autoconfigure</module>
+        <module>opentracing-spring-webflux-extension-starter</module>
     </modules>
-
-    <profiles>
-        <profile>
-            <id>spring4</id>  <!-- just to prevent default profile from taking effect -->
-        </profile>
-        <profile>
-            <id>spring5</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>opentracing-spring-webflux-extension</module>
-                <module>opentracing-spring-webflux-extension-autoconfigure</module>
-                <module>opentracing-spring-webflux-extension-starter</module>
-            </modules>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,6 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <slf4j.version>1.7.36</slf4j.version>
 
-        <spring4.version>4.3.30.RELEASE</spring4.version>
-        <spring-boot1.version>1.5.22.RELEASE</spring-boot1.version>
-
         <spring.version>5.3.17</spring.version>
         <spring-boot.version>2.6.6</spring-boot.version>
 
@@ -72,9 +69,6 @@
         <coroutines.version>1.6.0</coroutines.version>
         <kotest.version>5.1.0</kotest.version>
         <kotlin.code.style>official</kotlin.code.style>
-
-        <!-- testing-->
-        <groovy.version>3.0.10</groovy.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -274,25 +268,6 @@
                 <scope>test</scope>
             </dependency>
             <!-- testing: rest -->
-            <!-- spring4 has older versions of groovy -->
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-xml</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-json</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
-            </dependency>
 
             <dependency>
                 <groupId>io.rest-assured</groupId>
@@ -571,18 +546,6 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
@@ -609,14 +572,6 @@
         </plugins>
     </build>
     <profiles>
-        <profile>
-            <id>spring4</id>
-            <properties>
-                <spring.version>${spring4.version}</spring.version>
-                <spring-boot.version>${spring-boot1.version}</spring-boot.version>
-                <log4j.version>2.7</log4j.version>
-            </properties>
-        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     </licenses>
     <developers>
         <developer>
-            <name>Willi Schönborn</name>
-            <email>willi.schoenborn@zalando.de</email>
+            <name>Gregor Zeitlinger</name>
+            <email>gregor.zeitlinger@zalando.de</email>
             <organization>Zalando SE</organization>
             <organizationUrl>https://tech.zalando.com/</organizationUrl>
         </developer>


### PR DESCRIPTION
remove support for Spring 4 and Spring Boot 1.5, because they don't receive security fixes anymore - and thus the build is failing