### PR TITLE
prevent exception when a span is not present

### DIFF
--- a/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/DefaultFlow.java
+++ b/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/DefaultFlow.java
@@ -1,19 +1,24 @@
 package org.zalando.opentracing.flowid;
 
-import io.opentracing.Span;
-import io.opentracing.Tracer;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
+import javax.annotation.Nullable;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Slf4j
 @AllArgsConstructor
 final class DefaultFlow implements Flow {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultFlow.class.getName());
 
     private final Extractor extractor = new CompositeExtractor(
             new BaggageExtractor(),
@@ -26,24 +31,24 @@ final class DefaultFlow implements Flow {
 
     @Override
     public void readFrom(final UnaryOperator<String> reader) {
-        final Span span = activeSpan();
+        activeSpan().ifPresent(span -> {
+            final Optional<FlowId> now = extractor.extract(span, reader);
+            final Optional<FlowId> later = extractor.extract(span);
 
-        final Optional<FlowId> now = extractor.extract(span, reader);
-        final Optional<FlowId> later = extractor.extract(span);
+            final Optional<String> nowId = now.map(FlowId::getValue);
+            final Optional<String> laterId = later.map(FlowId::getValue);
 
-        final Optional<String> nowId = now.map(FlowId::getValue);
-        final Optional<String> laterId = later.map(FlowId::getValue);
-
-        if (nowId.equals(laterId)) {
-            later.ifPresent(flowId -> {
-                listener.onRead(span, flowId);
-            });
-        } else {
-            now.ifPresent(flowId -> {
-                bag(span, flowId);
-                listener.onRead(span, flowId);
-            });
-        }
+            if (nowId.equals(laterId)) {
+                later.ifPresent(flowId -> {
+                    listener.onRead(span, flowId);
+                });
+            } else {
+                now.ifPresent(flowId -> {
+                    bag(span, flowId);
+                    listener.onRead(span, flowId);
+                });
+            }
+        });
     }
 
     private void bag(final Span span, final FlowId flowId) {
@@ -52,14 +57,16 @@ final class DefaultFlow implements Flow {
 
     @Override
     public String currentId() {
-        return extractor.extract(activeSpan())
+        return activeSpan()
+                .flatMap(extractor::extract)
                 .map(FlowId::getValue)
-                .orElseThrow(IllegalStateException::new);
+                .orElse(null);
     }
 
     @Override
     public void writeTo(final BiConsumer<String, String> writer) {
-        extractor.extract(activeSpan())
+        activeSpan()
+                .flatMap(extractor::extract)
                 .map(FlowId::getValue)
                 .ifPresent(value ->
                         writer.accept(Header.FLOW_ID, value));
@@ -67,17 +74,21 @@ final class DefaultFlow implements Flow {
 
     @Override
     public <T> T write(final BiFunction<String, String, T> writer) {
-        return writer.apply(Header.FLOW_ID, currentId());
+        String currentId = currentId();
+        if (currentId != null) {
+            return writer.apply(Header.FLOW_ID, currentId);
+        }
+        return null;
     }
 
-    private Span activeSpan() {
+    private Optional<Span> activeSpan() {
         @Nullable final Span span = tracer.activeSpan();
 
         if (span == null) {
-            throw new IllegalStateException("No active span found");
+            LOG.warn("No active span found");
         }
 
-        return span;
+        return Optional.ofNullable(span);
     }
 
 }

--- a/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/Flow.java
+++ b/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/Flow.java
@@ -1,12 +1,13 @@
 package org.zalando.opentracing.flowid;
 
-import io.opentracing.Tracer;
-
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
-import static org.zalando.opentracing.flowid.FlowListener.composite;
+import javax.annotation.Nullable;
+
+import io.opentracing.Tracer;
+import static org.zalando.opentracing.flowid.FlowListener.*;
 
 public interface Flow {
 
@@ -30,11 +31,11 @@ public interface Flow {
 
     void readFrom(UnaryOperator<String> reader);
 
-    String currentId() throws IllegalStateException;
+    @Nullable String currentId();
 
     void writeTo(BiConsumer<String, String> writer);
 
-    <T> T write(BiFunction<String, String, T> writer);
+    @Nullable <T> T write(BiFunction<String, String, T> writer);
 
     static Flow create(final Tracer tracer) {
         return create(tracer, new TagFlowListener());

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
@@ -1,21 +1,19 @@
 package org.zalando.opentracing.flowid;
 
-import io.opentracing.noop.NoopTracerFactory;
-import org.junit.jupiter.api.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.opentracing.noop.NoopTracerFactory;
+import static java.util.Collections.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 class DefaultFlowNoopTracerTest {
     private final Flow unit = Flow.create(NoopTracerFactory.create());
 
     @Test
-    void shouldThrowNoActiveSpanFoundException() {
-        assertThrows(IllegalStateException.class, unit::currentId);
+    void shouldReturnNullOnNoActiveSpan() {
+        assertNull(unit.currentId());
     }
 
     @Test

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowTest.java
@@ -1,23 +1,19 @@
 package org.zalando.opentracing.flowid;
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.mock.MockSpan;
-import io.opentracing.mock.MockTracer;
-import org.junit.jupiter.api.Test;
-import org.zalando.opentracing.flowid.Flow.Baggage;
-import org.zalando.opentracing.flowid.Flow.Header;
-import org.zalando.opentracing.flowid.Flow.Tag;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import static java.util.Collections.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.zalando.opentracing.flowid.Flow.Baggage;
+import org.zalando.opentracing.flowid.Flow.Header;
+import org.zalando.opentracing.flowid.Flow.Tag;
 
 class DefaultFlowTest {
 
@@ -135,8 +131,8 @@ class DefaultFlowTest {
     }
 
     @Test
-    void shouldFailWithoutActiveSpan() {
-        assertThrows(IllegalStateException.class, unit::currentId);
+    void shouldReturnNullWithoutActiveSpan() {
+        assertNull(unit.currentId());
     }
 
 }

--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/base/ForwardingSpan.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/base/ForwardingSpan.java
@@ -13,7 +13,7 @@ import org.apiguardian.api.API;
 import static org.apiguardian.api.API.Status.*;
 
 /**
- * Implement <code>Supplier<Span></code> to support the OpenTracing shim:
+ * Implement {@link Supplier} to support the OpenTracing shim:
  * https://github.com/open-telemetry/opentelemetry-java/pull/4535
  */
 @API(status = EXPERIMENTAL)


### PR DESCRIPTION
prevent exception when a span is not present - usually because the filters are installed in the wrong order
Tracing tools must never cause the application to fail.