### PR TITLE
preserve the old behavior of Flow.currentId

### DIFF
--- a/opentracing-flowid/opentracing-flowid-servlet/src/test/java/org/zalando/opentracing/flowid/servlet/example/TraceServlet.java
+++ b/opentracing-flowid/opentracing-flowid-servlet/src/test/java/org/zalando/opentracing/flowid/servlet/example/TraceServlet.java
@@ -1,11 +1,12 @@
 package org.zalando.opentracing.flowid.servlet.example;
 
-import org.zalando.opentracing.flowid.Flow;
+import java.io.IOException;
 
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import org.zalando.opentracing.flowid.Flow;
 
 public final class TraceServlet extends HttpServlet {
 
@@ -17,7 +18,7 @@ public final class TraceServlet extends HttpServlet {
 
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws IOException {
-        response.getWriter().print(flow.currentId());
+        response.getWriter().print(flow.currentSpanId().orElse(null));
     }
 
 }

--- a/opentracing-flowid/opentracing-flowid/pom.xml
+++ b/opentracing-flowid/opentracing-flowid/pom.xml
@@ -13,8 +13,23 @@
             <artifactId>log4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-library</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/Flow.java
+++ b/opentracing-flowid/opentracing-flowid/src/main/java/org/zalando/opentracing/flowid/Flow.java
@@ -1,5 +1,6 @@
 package org.zalando.opentracing.flowid;
 
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
@@ -31,7 +32,13 @@ public interface Flow {
 
     void readFrom(UnaryOperator<String> reader);
 
-    @Nullable String currentId();
+    /**
+     * deprecated - please use {@link #currentSpanId()} because it doesn't throw an exception
+     */
+    @Deprecated
+    String currentId() throws IllegalStateException;
+
+    Optional<String> currentSpanId();
 
     void writeTo(BiConsumer<String, String> writer);
 

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowNoopTracerTest.java
@@ -4,8 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.opentracing.noop.NoopTracerFactory;
-import static java.util.Collections.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 class DefaultFlowNoopTracerTest {
@@ -13,13 +12,13 @@ class DefaultFlowNoopTracerTest {
 
     @Test
     void shouldReturnNullOnNoActiveSpan() {
-        assertNull(unit.currentId());
+        assertThat(unit.currentSpanId()).isEmpty();
     }
 
     @Test
     void writeToShouldNotThrow() {
         final Map<String, String> target = new HashMap<>();
         unit.writeTo(target::put);
-        assertEquals(emptyMap(), target);
+        assertThat(target).isEmpty();
     }
 }

--- a/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowTest.java
+++ b/opentracing-flowid/opentracing-flowid/src/test/java/org/zalando/opentracing/flowid/DefaultFlowTest.java
@@ -9,6 +9,7 @@ import io.opentracing.Span;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 import org.zalando.opentracing.flowid.Flow.Baggage;
@@ -27,7 +28,7 @@ class DefaultFlowTest {
         try (final Scope ignored = tracer.activateSpan(span)) {
             unit.readFrom(singletonMap(Header.FLOW_ID, "REcCvlqMSReeo7adheiYFA")::get);
 
-            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentId());
+            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentSpanId().get());
             assertEquals("REcCvlqMSReeo7adheiYFA", span.getBaggageItem(Baggage.FLOW_ID));
             assertEquals("REcCvlqMSReeo7adheiYFA", span.tags().get(Tag.FLOW_ID));
         }
@@ -41,7 +42,7 @@ class DefaultFlowTest {
         try (final Scope ignored = tracer.activateSpan(span)) {
             unit.readFrom(name -> null);
 
-            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentId());
+            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentSpanId().get());
             assertEquals("REcCvlqMSReeo7adheiYFA", span.getBaggageItem(Baggage.FLOW_ID));
             assertEquals("REcCvlqMSReeo7adheiYFA", span.tags().get(Tag.FLOW_ID));
         }
@@ -54,7 +55,7 @@ class DefaultFlowTest {
         try (final Scope ignored = tracer.activateSpan(span)) {
             unit.readFrom(name -> null);
 
-            assertEquals(span.context().toTraceId(), unit.currentId());
+            assertEquals(span.context().toTraceId(), unit.currentSpanId().get());
             assertNull(span.getBaggageItem(Baggage.FLOW_ID));
             assertFalse(span.tags().containsKey(Tag.FLOW_ID));
         }
@@ -68,7 +69,7 @@ class DefaultFlowTest {
         try (final Scope ignored = tracer.activateSpan(span)) {
             unit.readFrom(singletonMap(Header.FLOW_ID, "Rso72qSgLWPNlYIF_OGjvA")::get);
 
-            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentId());
+            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentSpanId().get());
             assertEquals("REcCvlqMSReeo7adheiYFA", span.getBaggageItem(Baggage.FLOW_ID));
             assertEquals("REcCvlqMSReeo7adheiYFA", span.tags().get(Tag.FLOW_ID));
         }
@@ -82,7 +83,7 @@ class DefaultFlowTest {
             final String traceId = span.context().toTraceId();
             unit.readFrom(singletonMap(Header.FLOW_ID, traceId)::get);
 
-            assertEquals(traceId, unit.currentId());
+            assertEquals(traceId, unit.currentSpanId().get());
             assertNull(span.getBaggageItem(Baggage.FLOW_ID));
             assertFalse(span.tags().containsKey(Tag.FLOW_ID));
         }
@@ -96,7 +97,7 @@ class DefaultFlowTest {
         try (final Scope ignored = tracer.activateSpan(span)) {
             unit.readFrom(singletonMap(Header.FLOW_ID, "REcCvlqMSReeo7adheiYFA")::get);
 
-            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentId());
+            assertEquals("REcCvlqMSReeo7adheiYFA", unit.currentSpanId().get());
             assertEquals("REcCvlqMSReeo7adheiYFA", span.getBaggageItem(Baggage.FLOW_ID));
             assertEquals("REcCvlqMSReeo7adheiYFA", span.tags().get(Tag.FLOW_ID));
         }
@@ -113,7 +114,7 @@ class DefaultFlowTest {
             unit.writeTo(target::put);
 
 
-            assertEquals(target.get(Header.FLOW_ID), unit.currentId());
+            assertEquals(target.get(Header.FLOW_ID), unit.currentSpanId().get());
         }
     }
 
@@ -126,13 +127,13 @@ class DefaultFlowTest {
 
             final Map<String, String> target = unit.write(Collections::singletonMap);
 
-            assertEquals(target.get(Header.FLOW_ID), unit.currentId());
+            assertEquals(target.get(Header.FLOW_ID), unit.currentSpanId().get());
         }
     }
 
     @Test
     void shouldReturnNullWithoutActiveSpan() {
-        assertNull(unit.currentId());
+        assertThat(unit.currentSpanId()).isEmpty();
     }
 
 }


### PR DESCRIPTION
preserve the old behavior of Flow.currentId - but deprecate it
This fixes compatability issues with libraries that depend on currentId throwing exceptions