### PR TITLE
Fix for proxytracer

### DIFF
--- a/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/core/ProxyTracer.java
+++ b/opentracing-proxy/opentracing-proxy/src/main/java/org/zalando/opentracing/proxy/core/ProxyTracer.java
@@ -75,4 +75,13 @@ public final class ProxyTracer implements ForwardingTracer {
         return scope;
     }
 
+    @Override
+    public Span activeSpan() {
+        Span span = ForwardingTracer.super.activeSpan();
+        if(span == null || span instanceof ProxySpan){
+            return span;
+        }
+        // for opentracing shim, it must still return ProxySpan
+        return new ProxySpan(this, span, registry);
+    }
 }


### PR DESCRIPTION
In case of opentracing shim the method activeSpan must return the Span of type ProxySpan.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
