### PR TITLE
Synchronize SPI decorator loading

### DIFF
--- a/opentracing-jdbc/opentracing-jdbc/src/main/java/org/zalando/opentracing/jdbc/span/ServiceLoaderSpanDecorator.java
+++ b/opentracing-jdbc/opentracing-jdbc/src/main/java/org/zalando/opentracing/jdbc/span/ServiceLoaderSpanDecorator.java
@@ -2,9 +2,12 @@ package org.zalando.opentracing.jdbc.span;
 
 import org.apiguardian.api.API;
 
+import java.util.List;
 import java.util.ServiceLoader;
 
 import static java.util.ServiceLoader.load;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.zalando.opentracing.jdbc.span.SpanDecorator.composite;
 
@@ -15,7 +18,11 @@ import static org.zalando.opentracing.jdbc.span.SpanDecorator.composite;
 public final class ServiceLoaderSpanDecorator extends ForwardingSpanDecorator {
 
     public ServiceLoaderSpanDecorator() {
-        super(composite(load(SpanDecorator.class)));
+        super(composite(loadDecorators()));
+    }
+
+    private static synchronized List<SpanDecorator> loadDecorators() {
+        return stream(load(SpanDecorator.class).spliterator(), false).collect(toList());
     }
 
 }

--- a/opentracing-servlet-extension/opentracing-servlet-extension/src/main/java/org/zalando/opentracing/servlet/extension/ServiceLoaderSpanDecorator.java
+++ b/opentracing-servlet-extension/opentracing-servlet-extension/src/main/java/org/zalando/opentracing/servlet/extension/ServiceLoaderSpanDecorator.java
@@ -3,9 +3,12 @@ package org.zalando.opentracing.servlet.extension;
 import io.opentracing.contrib.web.servlet.filter.ServletFilterSpanDecorator;
 import org.apiguardian.api.API;
 
+import java.util.List;
 import java.util.ServiceLoader;
 
 import static java.util.ServiceLoader.load;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 /**
@@ -15,7 +18,11 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 public final class ServiceLoaderSpanDecorator extends ForwardingSpanDecorator {
 
     public ServiceLoaderSpanDecorator() {
-        super(CompositeSpanDecorator.composite(load(ServletFilterSpanDecorator.class)));
+        super(CompositeSpanDecorator.composite(loadDecorators()));
+    }
+
+    private static synchronized List<ServletFilterSpanDecorator> loadDecorators() {
+        return stream(load(ServletFilterSpanDecorator.class).spliterator(), false).collect(toList());
     }
 
 }

--- a/opentracing-spring-extension/opentracing-spring-web-extension/src/main/java/org/zalando/opentracing/spring/web/extension/ServiceLoaderSpanDecorator.java
+++ b/opentracing-spring-extension/opentracing-spring-web-extension/src/main/java/org/zalando/opentracing/spring/web/extension/ServiceLoaderSpanDecorator.java
@@ -3,9 +3,12 @@ package org.zalando.opentracing.spring.web.extension;
 import io.opentracing.contrib.spring.web.interceptor.HandlerInterceptorSpanDecorator;
 import org.apiguardian.api.API;
 
+import java.util.List;
 import java.util.ServiceLoader;
 
 import static java.util.ServiceLoader.load;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.zalando.opentracing.spring.web.extension.CompositeSpanDecorator.composite;
 
@@ -17,6 +20,11 @@ public final class ServiceLoaderSpanDecorator
         extends ForwardingSpanDecorator {
 
     public ServiceLoaderSpanDecorator() {
-        super(composite(load(HandlerInterceptorSpanDecorator.class)));
+        super(composite(loadDecorators()));
     }
+
+    private static synchronized List<HandlerInterceptorSpanDecorator> loadDecorators() {
+        return stream(load(HandlerInterceptorSpanDecorator.class).spliterator(), false).collect(toList());
+    }
+
 }

--- a/opentracing-spring-extension/opentracing-spring-webflux-extension/src/main/java/org/zalando/opentracing/spring/webflux/extension/ServiceLoaderSpanDecorator.java
+++ b/opentracing-spring-extension/opentracing-spring-webflux-extension/src/main/java/org/zalando/opentracing/spring/webflux/extension/ServiceLoaderSpanDecorator.java
@@ -3,9 +3,12 @@ package org.zalando.opentracing.spring.webflux.extension;
 import io.opentracing.contrib.spring.web.webfilter.WebFluxSpanDecorator;
 import org.apiguardian.api.API;
 
+import java.util.List;
 import java.util.ServiceLoader;
 
 import static java.util.ServiceLoader.load;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 import static org.zalando.opentracing.spring.webflux.extension.CompositeSpanDecorator.composite;
 
@@ -17,6 +20,11 @@ public final class ServiceLoaderSpanDecorator
         extends ForwardingSpanDecorator {
 
     public ServiceLoaderSpanDecorator() {
-        super(composite(load(WebFluxSpanDecorator.class)));
+        super(composite(loadDecorators()));
     }
+
+    private static synchronized List<WebFluxSpanDecorator> loadDecorators() {
+        return stream(load(WebFluxSpanDecorator.class).spliterator(), false).collect(toList());
+    }
+
 }


### PR DESCRIPTION
Synchronize SPI span decorator loading and have them loaded eagerly.

## Motivation and Context

1. eagerly load decorators obtained via SPI to avoid exceptions in high-concurrency setups
2. instances of `ServiceLoader` are not thread-safe, iterating on the `Iterable` may yield exceptions if done concurrently
3. eager loading prevents any reloading functionality of `ServiceLoader` to work

Example exception (sadly `ServiceLoaderSpanDecorator` not rendered):
```
java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
	at java.lang.CompoundEnumeration.next(ClassLoader.java:2725)
	at java.lang.CompoundEnumeration.hasMoreElements(ClassLoader.java:2734)
	... 30 frames excluded
	at org.zalando.fauxpas.ThrowingSupplier.get(ThrowingSupplier.java:19)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at io.opentracing.contrib.concurrent.TracedRunnable.run(TracedRunnable.java:30)
	... 6 frames excluded
	at org.zalando.fauxpas.ThrowingFunction.apply(ThrowingFunction.java:19)
	... 5 frames excluded
```
See also https://github.com/zalando/riptide/pull/1462 for the same fix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have added tests to cover my changes.
